### PR TITLE
Replaced JSON & strings with bincode

### DIFF
--- a/artillery-core/Cargo.toml
+++ b/artillery-core/Cargo.toml
@@ -30,6 +30,7 @@ bastion-executor = "0.3.5"
 lightproc = "0.3.5"
 crossbeam-channel = "0.4.2"
 kaos = "0.1.1-alpha.2"
+bytes = { version = "1.1.0", features = [ "serde" ] }
 
 [dev-dependencies]
 bincode = "1.3.1"

--- a/artillery-core/Cargo.toml
+++ b/artillery-core/Cargo.toml
@@ -18,7 +18,7 @@ failure_derive = "0.1.8"
 bastion-utils = "0.3.2"
 cuneiform-fields = "0.1.0"
 serde = { version = "1.0.114", features = ["derive"] }
-serde_json = "1.0.56"
+bincode = "1.3.3"
 uuid = { version = "0.8.1", features = ["serde", "v4"] }
 chrono = { version = "0.4.13", features = ["serde"] }
 rand = "0.7.3"

--- a/artillery-core/examples/cball_sd_infection.rs
+++ b/artillery-core/examples/cball_sd_infection.rs
@@ -86,7 +86,7 @@ fn main() {
     };
 
     let reply = ServiceDiscoveryReply {
-        serialized_data: serde_json::to_string(&epidemic_sd_config).unwrap(),
+        serialized_data: bincode::serialize(&epidemic_sd_config).unwrap(),
     };
 
     let sd = MulticastServiceDiscovery::new_service_discovery(service_discovery, reply).unwrap();
@@ -109,7 +109,7 @@ fn main() {
         .expect("cannot start cluster-event-poller");
 
     for discovery in discoveries.iter() {
-        let discovery: ExampleSDReply = serde_json::from_str(&discovery.serialized_data).unwrap();
+        let discovery: ExampleSDReply = bincode::deserialize(&discovery.serialized_data).unwrap();
         if discovery.port != epidemic_sd_config.port {
             debug!("Seed node address came");
             let seed_node = format!("{}:{}", epidemic_sd_config.ip, discovery.port);

--- a/artillery-core/examples/cball_sd_infection.rs
+++ b/artillery-core/examples/cball_sd_infection.rs
@@ -3,6 +3,7 @@ extern crate pretty_env_logger;
 #[macro_use]
 extern crate log;
 
+use bytes::Bytes;
 use clap::*;
 use std::convert::TryInto;
 use std::fs::File;
@@ -86,7 +87,7 @@ fn main() {
     };
 
     let reply = ServiceDiscoveryReply {
-        serialized_data: bincode::serialize(&epidemic_sd_config).unwrap(),
+        serialized_data: Bytes::from(bincode::serialize(&epidemic_sd_config).unwrap()),
     };
 
     let sd = MulticastServiceDiscovery::new_service_discovery(service_discovery, reply).unwrap();

--- a/artillery-core/src/epidemic/cluster.rs
+++ b/artillery-core/src/epidemic/cluster.rs
@@ -3,6 +3,7 @@ use crate::epidemic::cluster_config::ClusterConfig;
 use crate::epidemic::state::{ArtilleryClusterEvent, ArtilleryClusterRequest};
 use crate::errors::*;
 use bastion_executor::prelude::*;
+use bytes::Bytes;
 use lightproc::{proc_stack::ProcStack, recoverable_handle::RecoverableHandle};
 use serde::Serialize;
 use std::net::SocketAddr;
@@ -57,7 +58,7 @@ impl Cluster {
         self.comm
             .send(ArtilleryClusterRequest::Payload(
                 id,
-                bincode::serialize(msg).expect("Failed to serialize payload"),
+                Bytes::from(bincode::serialize(msg).expect("Failed to serialize payload")),
             ))
             .unwrap();
     }

--- a/artillery-core/src/epidemic/cluster.rs
+++ b/artillery-core/src/epidemic/cluster.rs
@@ -4,7 +4,7 @@ use crate::epidemic::state::{ArtilleryClusterEvent, ArtilleryClusterRequest};
 use crate::errors::*;
 use bastion_executor::prelude::*;
 use lightproc::{proc_stack::ProcStack, recoverable_handle::RecoverableHandle};
-use std::convert::AsRef;
+use serde::Serialize;
 use std::net::SocketAddr;
 use std::{
     future::Future,
@@ -53,11 +53,11 @@ impl Cluster {
         let _ = self.comm.send(ArtilleryClusterRequest::AddSeed(addr));
     }
 
-    pub fn send_payload<T: AsRef<str>>(&self, id: Uuid, msg: T) {
+    pub fn send_payload<T: Serialize>(&self, id: Uuid, msg: &T) {
         self.comm
             .send(ArtilleryClusterRequest::Payload(
                 id,
-                msg.as_ref().to_string(),
+                bincode::serialize(msg).expect("Failed to serialize payload"),
             ))
             .unwrap();
     }

--- a/artillery-core/src/epidemic/member.rs
+++ b/artillery-core/src/epidemic/member.rs
@@ -227,7 +227,7 @@ mod test {
 
         let decoded: ArtilleryMember = bincode::deserialize(&encoded).unwrap();
 
-        let json_encoded = serde_json::to_string(&member).unwrap();
+        let json_encoded = bincode::serialize(&member).unwrap();
         dbg!(json_encoded);
 
         assert_eq!(decoded, member);

--- a/artillery-core/src/epidemic/member.rs
+++ b/artillery-core/src/epidemic/member.rs
@@ -208,6 +208,7 @@ mod test {
     use std::str::FromStr;
 
     use super::{ArtilleryMember, ArtilleryMemberState};
+    use bytes::Bytes;
     use chrono::{Duration, Utc};
 
     use uuid;
@@ -222,12 +223,12 @@ mod test {
             last_state_change: Utc::now() - Duration::days(1),
         };
 
-        let encoded = bincode::serialize(&member).unwrap();
+        let encoded = Bytes::from(bincode::serialize(&member).unwrap());
         dbg!(encoded.len());
 
         let decoded: ArtilleryMember = bincode::deserialize(&encoded).unwrap();
 
-        let json_encoded = bincode::serialize(&member).unwrap();
+        let json_encoded = Bytes::from(bincode::serialize(&member).unwrap());
         dbg!(json_encoded);
 
         assert_eq!(decoded, member);

--- a/artillery-core/src/epidemic/state.rs
+++ b/artillery-core/src/epidemic/state.rs
@@ -2,6 +2,7 @@ use super::cluster_config::ClusterConfig;
 use super::membership::ArtilleryMemberList;
 use crate::epidemic::member::{ArtilleryMember, ArtilleryMemberState, ArtilleryStateChange};
 use crate::errors::*;
+use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use cuneiform_fields::prelude::*;
 use mio::net::UdpSocket;
@@ -34,7 +35,7 @@ pub enum ArtilleryMemberEvent {
     SuspectedDown(ArtilleryMember),
     WentDown(ArtilleryMember),
     Left(ArtilleryMember),
-    Payload(ArtilleryMember, Vec<u8>),
+    Payload(ArtilleryMember, Bytes),
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -54,7 +55,7 @@ enum Request {
     Ack,
     Ping(EncSocketAddr),
     AckHost(ArtilleryMember),
-    Payload(Uuid, Vec<u8>),
+    Payload(Uuid, Bytes),
 }
 
 #[derive(Debug, Clone)]
@@ -70,7 +71,7 @@ pub enum ArtilleryClusterRequest {
     React(TargetedRequest),
     LeaveCluster,
     Exit(Sender<()>),
-    Payload(Uuid, Vec<u8>),
+    Payload(Uuid, Bytes),
 }
 
 const UDP_SERVER: Token = Token(0);

--- a/artillery-core/src/epidemic/state.rs
+++ b/artillery-core/src/epidemic/state.rs
@@ -230,7 +230,7 @@ impl ArtilleryEpidemic {
                 .push((timeout, request.target, message.state_changes.clone()));
         }
 
-        let encoded = bincode::serialize(&message).unwrap();
+        let encoded = Bytes::from(bincode::serialize(&message).unwrap());
 
         assert!(encoded.len() < self.config.network_mtu);
 
@@ -505,7 +505,7 @@ fn build_message(
             state_changes: (&state_changes[..i]).to_vec(),
         };
 
-        let encoded = bincode::serialize(&message).unwrap();
+        let encoded = Bytes::from(bincode::serialize(&message).unwrap());
         if encoded.len() >= network_mtu {
             return message;
         }

--- a/artillery-core/src/errors.rs
+++ b/artillery-core/src/errors.rs
@@ -34,8 +34,8 @@ impl From<io::Error> for ArtilleryError {
     }
 }
 
-impl From<serde_json::error::Error> for ArtilleryError {
-    fn from(e: serde_json::error::Error) -> Self {
+impl From<bincode::Error> for ArtilleryError {
+    fn from(e: bincode::Error) -> Self {
         ArtilleryError::ClusterMessageDecode(e.to_string())
     }
 }

--- a/artillery-ddata/Cargo.toml
+++ b/artillery-ddata/Cargo.toml
@@ -10,7 +10,7 @@ failure = "0.1.7"
 thrift = "0.13.0"
 t1ha = "0.1"
 crossbeam-channel = "0.4"
-
+bytes = { version = "1", features = [ "serde" ] }
 
 [dev-dependencies]
 clap = "2.33.0"

--- a/artillery-ddata/src/craq/client.rs
+++ b/artillery-ddata/src/craq/client.rs
@@ -6,6 +6,7 @@ use super::{
     proto::{CraqConsistencyModel, CraqObject, TCraqServiceSyncClient},
 };
 use std::net::{SocketAddr, ToSocketAddrs};
+use bytes::Bytes;
 use thrift::protocol::{TBinaryInputProtocol, TBinaryOutputProtocol};
 use thrift::transport::{
     TFramedReadTransport, TFramedWriteTransport, TIoChannel, TTcpChannel as BiTcp,
@@ -14,7 +15,7 @@ use thrift::transport::{
 pub struct ReadObject {
     ///
     /// Object's value.
-    value: Vec<u8>,
+    value: Bytes,
     ///
     /// Whether the read was dirty (true) or clean (false).
     dirty: bool,
@@ -23,7 +24,7 @@ pub struct ReadObject {
 impl ReadObject {
     ///
     /// Creates a new wrapper Read Object
-    pub fn new(value: Vec<u8>, dirty: bool) -> Self {
+    pub fn new(value: Bytes, dirty: bool) -> Self {
         Self { value, dirty }
     }
 }
@@ -93,7 +94,7 @@ impl DDataCraqClient {
     /// Writes an object to the cluster, returning the new object version or -1 upon failure.
     pub fn write(&mut self, value: String) -> Result<i64> {
         let mut obj = CraqObject::default();
-        obj.value = Some(value.into_bytes());
+        obj.value = Some(value.into());
         Ok(self.cc.write(obj)?)
     }
 
@@ -112,7 +113,7 @@ impl DDataCraqClient {
     /// Performs a test-and-set operation, returning the new object version or -1 upon failure.
     pub fn test_and_set(&mut self, value: String, expected_version: i64) -> Result<i64> {
         let mut obj = CraqObject::default();
-        obj.value = Some(value.into_bytes());
+        obj.value = Some(value.into());
         Ok(self.cc.test_and_set(obj, expected_version)?)
     }
 }

--- a/artillery-ddata/src/craq/proto.rs
+++ b/artillery-ddata/src/craq/proto.rs
@@ -16,6 +16,7 @@ use std::error::Error;
 use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::rc::Rc;
+use bytes::Bytes;
 use thrift::OrderedFloat;
 
 use thrift::protocol::field_id;
@@ -78,14 +79,14 @@ pub type Version = i64;
 /// Object envelope.
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct CraqObject {
-    pub value: Option<Vec<u8>>,
+    pub value: Option<Bytes>,
     pub dirty: Option<bool>,
 }
 
 impl CraqObject {
     pub fn new<F1, F2>(value: F1, dirty: F2) -> CraqObject
     where
-        F1: Into<Option<Vec<u8>>>,
+        F1: Into<Option<Bytes>>,
         F2: Into<Option<bool>>,
     {
         CraqObject {
@@ -95,7 +96,7 @@ impl CraqObject {
     }
     pub fn read_from_in_protocol(i_prot: &mut dyn TInputProtocol) -> thrift::Result<CraqObject> {
         i_prot.read_struct_begin()?;
-        let mut f_1: Option<Vec<u8>> = None;
+        let mut f_1: Option<Bytes> = None;
         let mut f_2: Option<bool> = None;
         loop {
             let field_ident = i_prot.read_field_begin()?;
@@ -106,7 +107,7 @@ impl CraqObject {
             match field_id {
                 1 => {
                     let val = i_prot.read_bytes()?;
-                    f_1 = Some(val);
+                    f_1 = Some(val.into());
                 }
                 2 => {
                     let val = i_prot.read_bool()?;
@@ -152,7 +153,7 @@ impl CraqObject {
 impl Default for CraqObject {
     fn default() -> Self {
         CraqObject {
-            value: Some(Vec::new()),
+            value: Some(Bytes::new()),
             dirty: Some(false),
         }
     }

--- a/site/building-blocks/primitives.md
+++ b/site/building-blocks/primitives.md
@@ -48,7 +48,7 @@ let epidemic_sd_config = ExampleSDReply {
 };
 
 let reply = ServiceDiscoveryReply {
-    serialized_data: serde_json::to_string(&epidemic_sd_config).unwrap(),
+    serialized_data: bincode::serialize(&epidemic_sd_config).unwrap(),
 };
 
 // Initialize receiver channels
@@ -67,7 +67,7 @@ if let Some(_) = seeker {
 
 for discovery in discoveries.iter() {
     let discovery: ExampleSDReply =
-        serde_json::from_str(&discovery.serialized_data).unwrap();
+        bincode::deserialize(&discovery.serialized_data).unwrap();
     if discovery.port != epidemic_sd_config.port {
         debug!("Seed node address came");
         let seed_node = format!("{}:{}", discovery.ip, discovery.port);


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/bastion-rs/.github/blob/master/CONTRIBUTING.md
-->

# Update to message and packet content

This PR changes the way messages are sent between nodes, it replaces the usage of JSON and String-based payload with bincode based payloads. The ultimate goal of this change is to allow [bastion](https://github.com/bastion-rs/bastion) to exchange serialized messages instead of text between cluster members.

## Impact
This fairly simple change has a few positive and negative impacts:

### The pros
- the new serialization format is more efficient and should lead to smaller packet sizes (~60% according to [these benchmarks](https://github.com/djkoloski/rust_serialization_benchmark) and [this article](https://blog.logrocket.com/rust-serialization-whats-ready-for-production-today/))
- allows sending packets that aren't text-based
- using bincode, it should be faster than JSON (some x3.5 faster according to [this article](https://blog.logrocket.com/rust-serialization-whats-ready-for-production-today/) and x2.5 faster according to [these benchmarks](https://github.com/djkoloski/rust_serialization_benchmark)))
- because it's still using serde, switching the (de)serialization backend should be very easy and could be done with features

### The cons
- this loses observability, the content of the packet is now a binary data
- the single choice of bincode may not be to the taste of everybody, letting users select the format may be of interest

## Tests

Currently, I have not written additional tests for this, however, with the additional work I have done on bastion and the showcase repos (forks on my account), it works as expected. And existing tests seem to run fine.

## User facing changes
The breaking changes that appear are the following:

- `ArtilleryMemberEvent::Payload` now contains a `Vec<u8>` instead of a `String`
- `Cluster::send_payload` now enforces a trait bound of `Serialize` instead of `AsRef<str>`

This changes do have consequences for people using these features as they completely change the responsability of the user. Instead of having to "prepare"/serialize the data externally, it is now done internally. I belive this change is logical as serde is a very widely used crate. However, this could be changed by adding a `Cluster::send_raw_payload` that takes a `Vec<u8>` instead of a message and sends that instead.


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] tests are passing with `cargo test`. 
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message is clear

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
